### PR TITLE
fix: typo in cli command help

### DIFF
--- a/content_types/__init__.py
+++ b/content_types/__init__.py
@@ -502,7 +502,7 @@ def cli():
         content-types my_file.jpg
     """
     if len(sys.argv) < 2:
-        print('Usage: contenttypes [FILENAME_OR_EXTENSION]\nExample: contenttypes .jpg')
+        print('Usage: content-types [FILENAME_OR_EXTENSION]\nExample: content-types .jpg')
         sys.exit(1)
 
     filename = sys.argv[1]


### PR DESCRIPTION
The cli command for content-type is `content-type [file_name_or_extension]` but help has a typo which says `contenttypes [file_name_or_extension]` which is wrong.